### PR TITLE
Update README for personal site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,39 @@
-# Astro Starter Kit: Minimal
+# Personal Site
 
-```sh
-npm create astro@latest -- --template minimal
+This is the source code for [babak.dev](https://babak.dev), a simple single-page site built with **Astro**. The UI is written in **React** and styled with **Tailwind CSS**. It features smooth animations with Framer Motion and includes two sections:
+
+- **About** – information about Babak Rahimi
+- **Contact** – links to social profiles and email
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The site will be available at `http://localhost:4321`.
+3. Create a production build:
+   ```bash
+   npm run build
+   ```
+4. Preview the build locally:
+   ```bash
+   npm run preview
+   ```
+
+## Project structure
+
 ```
-
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
+├── public/          # Static assets
 ├── src/
-│   └── pages/
-│       └── index.astro
+│   ├── components/  # React components
+│   ├── pages/       # Astro pages
+│   └── styles/      # Global styles
 └── package.json
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+The entry page is `src/pages/index.astro` which loads the React `App` component.


### PR DESCRIPTION
## Summary
- update documentation to reflect the current React + Tailwind personal site

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d3241b8508326a2aeed3b407e1dc1